### PR TITLE
fix webpack-dev-server hot config

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "webpack.config.js",
   "scripts": {
     "prestart": "webpack",
-    "start": "webpack-dev-server --content-base dist/"
+    "start": "webpack-dev-server"
   },
   "author": "Ean Platter <eanplatter@gmail.com> (eanplatter.github.io)",
   "license": "ISC",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 
-var htmlWebpackPlugin = new HtmlWebpackPlugin({
+var HTMLWebpackPlugin = new HtmlWebpackPlugin({
   template: __dirname + '/app/index.html',
   hash: true,
   filename: 'index.html',
@@ -28,7 +28,7 @@ module.exports = {
       },
     ]
   },
-  plugins: [htmlWebpackPlugin, HotReloader],
+  plugins: [HTMLWebpackPlugin, HotReloader],
   devServer: {
     contentBase: __dirname + '/dist',
     hot: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 
-var HTMLWebpackPlugin = new HtmlWebpackPlugin({
+var htmlWebpackPlugin = new HtmlWebpackPlugin({
   template: __dirname + '/app/index.html',
   hash: true,
   filename: 'index.html',
@@ -12,7 +12,7 @@ var HotReloader = new webpack.HotModuleReplacementPlugin();
 module.exports = {
   entry: [
     'webpack-dev-server/client?http://localhost:8080',
-    'webpack/hot/only-dev-server',
+    'webpack/hot/dev-server',
     './app/App.js'
   ],
   output: {
@@ -28,5 +28,9 @@ module.exports = {
       },
     ]
   },
-  plugins: [HTMLWebpackPlugin, HotReloader]
+  plugins: [htmlWebpackPlugin, HotReloader],
+  devServer: {
+    contentBase: __dirname + '/dist',
+    hot: true,
+  }
 };


### PR DESCRIPTION
### Issue

The config uses `react-hot` but `webpack-dev-server`'s `hot` option was never enabled, so there were only full page refreshes.
### Config

CLI docs:

> To enable Hot Module Replacement with the webpack-dev-server specify --hot on the command line.

Config docs:

> add hot: true the the webpack-dev-server configuration to enable HMR on the server
### Console Output

Note the console output before only included HMR, hot module replacement (added by the plugin):

![image](https://cloud.githubusercontent.com/assets/5067638/11579110/1ab9444a-99e0-11e5-88e8-0125d6e8d37b.png)

Now, it includes WDS, webpack dev server output:

![image](https://cloud.githubusercontent.com/assets/5067638/11579137/38d98610-99e0-11e5-8d59-f7981e1f55b7.png)

So, when a component is updated it can be hot loaded instead of doing a full page refresh.
